### PR TITLE
Bugfix - maximum number in the sequence

### DIFF
--- a/prufer/prufer.py
+++ b/prufer/prufer.py
@@ -13,7 +13,7 @@ Tree = List[Edge]
 def build_tree(arr: List[int]) -> Tree:
     '''Converts a Prüfer sequence to its respective tree.'''
 
-    if any([index > len(arr) for index in arr]):
+    if any([index > len(arr)+1 for index in arr]):
         raise ValueError('All elements must be less than the length of the list.')
 
     tree = []


### PR DESCRIPTION
The highest possible number in the Prüfer sequence is n-1 for a length of n-2